### PR TITLE
Don't install the shopper.txt file in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,4 +5,3 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
 
 install(TARGETS ${CMAKE_PROJECT_NAME}
 	DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES shopper.txt DESTINATION /home/ceres/)


### PR DESCRIPTION
This removes the installation of the sample shopper.txt file so that it can be done properly instead within the bitbake recipe file.