### PR TITLE
Port to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,17 @@ project(asteroid-shopper
 	DESCRIPTION "A simple shopping list app for AsteroidOS")
 
 find_package(ECM REQUIRED NO_MODULE)
-find_package(AsteroidApp REQUIRED)
+find_package(AsteroidApp6 REQUIRED)
 
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ASTEROID_MODULE_PATH})
 
 include(FeatureSummary)
 include(GNUInstallDirs)
 include(ECMFindQmlModule)
-include(AsteroidCMakeSettings)
-include(AsteroidTranslations)
+include(Asteroid6CMakeSettings)
+include(Asteroid6Translations)
 
-find_package(Qt5 COMPONENTS Core Qml Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Qml Quick REQUIRED)
 
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} ${CMAKE_PROJECT_NAME})

--- a/src/AllListsPage.qml
+++ b/src/AllListsPage.qml
@@ -17,9 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.utils 1.0
-import org.asteroid.controls 1.0
+import QtQuick
+import org.asteroid.utils
+import org.asteroid.controls
 
 Item {
     id: allListsPage

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(${CMAKE_PROJECT_NAME} main.cpp FileHelper.cpp resources.qrc)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
-    AsteroidApp)
+    Asteroid::AsteroidApp6)
 install(TARGETS ${CMAKE_PROJECT_NAME}
     DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/CategoryEditDialog.qml
+++ b/src/CategoryEditDialog.qml
@@ -17,9 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.utils 1.0
-import org.asteroid.controls 1.0
+import QtQuick
+import org.asteroid.utils
+import org.asteroid.controls
 
 Item {
     id: categoryEditDialog

--- a/src/EditDialog.qml
+++ b/src/EditDialog.qml
@@ -17,9 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.utils 1.0
-import org.asteroid.controls 1.0
+import QtQuick
+import org.asteroid.utils
+import org.asteroid.controls
 
 Item {
     id: editDialog

--- a/src/FileHelper.cpp
+++ b/src/FileHelper.cpp
@@ -49,7 +49,6 @@ QString FileHelper::readFile(const QString &listName)
         return QString();
     }
     QTextStream in(&file);
-    in.setCodec("UTF-8");
     QString content = in.readAll();
     file.close();
     return content;
@@ -65,7 +64,6 @@ bool FileHelper::writeFile(const QString &listName, const QString &content)
         return false;
     }
     QTextStream out(&file);
-    out.setCodec("UTF-8");
     out << content;
     file.close();
     return true;

--- a/src/ShoppingListPage.qml
+++ b/src/ShoppingListPage.qml
@@ -17,9 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.utils 1.0
-import org.asteroid.controls 1.0
+import QtQuick
+import org.asteroid.utils
+import org.asteroid.controls
 
 Item {
     id: shoppingListPage

--- a/src/main.qml
+++ b/src/main.qml
@@ -17,11 +17,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import Nemo.Configuration 1.0
-import org.asteroid.utils 1.0
-import org.asteroid.controls 1.0
-import org.asteroid.shopper 1.0
+import QtQuick
+import Nemo.Configuration
+import org.asteroid.utils
+import org.asteroid.controls
+import org.asteroid.shopper
 
 Application {
     id: root


### PR DESCRIPTION
Qt6 port: AsteroidApp6 CMake family, versionless QML imports. Additionally: QTextStream::setCodec calls removed (API removed in Qt6, UTF-8 is default). Compile-verified against the qt6 sysroot, image-integrated, and launch-tested on skipjack and beluga hardware 2026-07-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)